### PR TITLE
Support awkt metadata annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ Visualize and navigate files containing WKT (Well Known Text) geometries in Visu
 - Instantly visualizes WKT geometries in the current text editor.
 - Highlights the current geometry as you navigate through text.
 - Selects the corresponding text when you click a geometry in the viewer.
+- Supports optional `[awkt ...]` metadata annotations for WKT embedded in logs.
+
+## Annotated WKT Metadata
+
+WKT Viewer can attach lightweight metadata to geometries found in generic log files:
+
+```text
+[awkt id=stroke-01234 tag=sweep-0007 label=01234] LINESTRING (0 0, 10 0)
+```
+
+The annotation applies to the first WKT geometry after the `[awkt ...]` block, up until the next annotation block. Unannotated WKT still renders normally.
+
+Supported keys are `id`, `tag`, and `label`. Unknown `key=value` fields are preserved for details, but do not affect rendering.
 
 ## Quick Start
 

--- a/extension/src/wkt.test.ts
+++ b/extension/src/wkt.test.ts
@@ -115,4 +115,76 @@ POLYGON (
         assert.equal(result[1].wkt, 'LINESTRING EMPTY')
         assert.equal(result[2].wkt, 'POINT(2 2)')
     })
+
+    test('attaches same-line awkt metadata to the following WKT', () => {
+        const input = '[awkt id=stroke-01234 tag=sweep-0007 label=01234 foo=bar] LINESTRING (0 0, 10 0)'
+        const result = extractWkt(input)
+
+        assert.equal(result.length, 1)
+        assert.equal(result[0].wkt, 'LINESTRING (0 0, 10 0)')
+        assert.deepStrictEqual(result[0].annotation, {
+            fields: {
+                id: 'stroke-01234',
+                tag: 'sweep-0007',
+                label: '01234',
+                foo: 'bar',
+            },
+            id: 'stroke-01234',
+            tag: 'sweep-0007',
+            label: '01234',
+            start: 0,
+            end: input.indexOf(']') + 1,
+            line: 0,
+            endLine: 0,
+        })
+    })
+
+    test('attaches next-line awkt metadata to the following WKT', () => {
+        const input = '[awkt id=stroke-001 tag=sweep-01 label=1]\nLINESTRING (0 0, 10 0)'
+        const result = extractWkt(input)
+
+        assert.equal(result.length, 1)
+        assert.equal(result[0].line, 1)
+        assert.equal(result[0].annotation?.id, 'stroke-001')
+        assert.equal(result[0].annotation?.line, 0)
+    })
+
+    test('attaches multiple inline awkt annotations on one line', () => {
+        const input = '[DBG] Generated: [awkt id=stroke-002 tag=sweep-01 label=2] LINESTRING (10 0, 20 0), [awkt id=stroke-003 tag=sweep-02 label=3] LINESTRING (0 10, 20 10)'
+        const result = extractWkt(input)
+
+        assert.equal(result.length, 2)
+        assert.equal(result[0].annotation?.id, 'stroke-002')
+        assert.equal(result[0].annotation?.tag, 'sweep-01')
+        assert.equal(result[1].annotation?.id, 'stroke-003')
+        assert.equal(result[1].annotation?.tag, 'sweep-02')
+    })
+
+    test('uses awkt metadata only for the first following WKT', () => {
+        const input = '[awkt id=stroke-001] POINT(0 0) POINT(1 1)'
+        const result = extractWkt(input)
+
+        assert.equal(result.length, 2)
+        assert.equal(result[0].annotation?.id, 'stroke-001')
+        assert.equal(result[1].annotation, undefined)
+    })
+
+    test('replaces orphan awkt metadata when another annotation appears before WKT', () => {
+        const input = '[awkt id=orphan] no geometry here [awkt id=stroke-001] POINT(0 0)'
+        const result = extractWkt(input)
+
+        assert.equal(result.length, 1)
+        assert.equal(result[0].annotation?.id, 'stroke-001')
+    })
+
+    test('ignores malformed awkt annotations without dropping nearby WKT', () => {
+        const input = '[awkt id] POINT(0 0) [awkt id=] POINT(1 1)'
+        const result = extractWkt(input)
+
+        assert.equal(result.length, 2)
+        assert.equal(result[0].wkt, 'POINT(0 0)')
+        assert.equal(result[0].annotation, undefined)
+        assert.equal(result[1].wkt, 'POINT(1 1)')
+        assert.equal(result[1].annotation, undefined)
+    })
 })

--- a/extension/src/wkt.ts
+++ b/extension/src/wkt.ts
@@ -1,4 +1,4 @@
-import { type WktToken } from '@wkt-viewer/shared'
+import { type WktAnnotation, type WktToken } from '@wkt-viewer/shared'
 
 export type { WktToken } from '@wkt-viewer/shared'
 
@@ -6,8 +6,11 @@ export type { WktToken } from '@wkt-viewer/shared'
 
 const enum CC {
     A = 65, Z = 90, a = 97, z = 122,
-    LParen = 40, RParen = 41, NL = 10,
+    LParen = 40, RParen = 41, LBracket = 91, NL = 10,
 }
+
+const ANNOTATION_KEYWORD = 'AWKT'
+const ANNOTATION_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_-]*$/
 
 const TOP = [
     'POINT', 'LINESTRING', 'POLYGON',
@@ -19,6 +22,13 @@ type TOPKW = (typeof TOP)[number]
 /** fast ASCII alpha check */
 const isAlpha = (c: number) =>
     (c >= CC.A && c <= CC.Z) || (c >= CC.a && c <= CC.z)
+
+type AnnotationParseResult = {
+    annotation?: WktAnnotation
+    consumed: boolean
+    end: number
+    endLine: number
+}
 
 /*───────────────────────── core parser ───────────────────────────*/
 
@@ -33,6 +43,7 @@ export function extractWkt(
 
     let i = 0                // cursor
     let line = 0             // current 0-based line number
+    let pendingAnnotation: WktAnnotation | undefined
 
     while (i < len && out.length < maxTokens) {
 
@@ -50,6 +61,16 @@ export function extractWkt(
         while (i < len && isAlpha(upper.charCodeAt(i))) i++
         const word = upper.slice(wordStart, i)
 
+        if (word === ANNOTATION_KEYWORD && wordStart > 0 && input.charCodeAt(wordStart - 1) === CC.LBracket) {
+            const result = parseAwktAnnotation(input, wordStart - 1, startLine)
+            pendingAnnotation = result.annotation
+            if (result.consumed) {
+                i = result.end
+                line = result.endLine
+            }
+            continue
+        }
+
         if (!TOP.includes(word as TOPKW)) continue         // not a WKT keyword
 
         /* ---- skip whitespace (tracking newlines) ---- */
@@ -61,12 +82,15 @@ export function extractWkt(
         /* ---- handle EMPTY (no parentheses) ---- */
         if (upper.startsWith('EMPTY', i)) {
             const end = i + 5
-            out.push({
+            const token: WktToken = {
                 wkt: input.slice(wordStart, end),
                 start: wordStart, end,
                 line: startLine,
                 endLine: line
-            })
+            }
+            if (pendingAnnotation) token.annotation = pendingAnnotation
+            out.push(token)
+            pendingAnnotation = undefined
             i = end
             continue
         }
@@ -87,18 +111,77 @@ export function extractWkt(
             continue
         }
 
-        out.push({
+        const token: WktToken = {
             wkt: input.slice(wordStart, endIdx + 1),
             start: wordStart, end: endIdx + 1,
             line: startLine,
             endLine
-        })
+        }
+        if (pendingAnnotation) token.annotation = pendingAnnotation
+        out.push(token)
+        pendingAnnotation = undefined
 
         i = endIdx + 1
         line = endLine
     }
 
     return out
+}
+
+function parseAwktAnnotation(str: string, start: number, startLine: number): AnnotationParseResult {
+    const len = str.length
+    const nl = str.indexOf('\n', start)
+    const cr = str.indexOf('\r', start)
+    const lineEnd = Math.min(
+        nl === -1 ? len : nl,
+        cr === -1 ? len : cr,
+    )
+    const close = str.indexOf(']', start)
+
+    if (close === -1 || close > lineEnd) {
+        return { consumed: false, end: start, endLine: startLine }
+    }
+
+    const body = str.slice(start + ANNOTATION_KEYWORD.length + 1, close).trim()
+    const fields = parseAwktFields(body)
+
+    if (!fields) {
+        return { consumed: true, end: close + 1, endLine: startLine }
+    }
+
+    return {
+        annotation: {
+            fields,
+            id: fields.id,
+            tag: fields.tag,
+            label: fields.label,
+            start,
+            end: close + 1,
+            line: startLine,
+            endLine: startLine,
+        },
+        consumed: true,
+        end: close + 1,
+        endLine: startLine,
+    }
+}
+
+function parseAwktFields(body: string): Record<string, string> | null {
+    if (body.length === 0) return null
+
+    const fields: Record<string, string> = {}
+    for (const part of body.split(/\s+/)) {
+        const eq = part.indexOf('=')
+        if (eq <= 0 || eq === part.length - 1) return null
+
+        const key = part.slice(0, eq)
+        const value = part.slice(eq + 1)
+        if (!ANNOTATION_KEY_PATTERN.test(key)) return null
+
+        fields[key] = value
+    }
+
+    return fields
 }
 
 /*──── helper that also tracks line number while counting parens ───*/

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,9 +1,21 @@
+export type WktAnnotation = {
+    fields: Record<string, string>
+    id?: string
+    tag?: string
+    label?: string
+    start: number
+    end: number
+    line: number
+    endLine: number
+}
+
 export type WktToken = {
     wkt: string
     start: number
     end: number
     line: number
     endLine: number
+    annotation?: WktAnnotation
 }
 
 export type MsgToWebview =

--- a/webview/src/App.test.tsx
+++ b/webview/src/App.test.tsx
@@ -75,6 +75,38 @@ describe('wktTokensToGeomObjects', () => {
         expect(geomObjects[2].feature.geometry.type).toBe('LineString')
         expect((geomObjects[2].feature.geometry as GeoJSON.LineString).coordinates).toEqual([])
     })
+
+    it('preserves token annotation metadata on geometry objects', () => {
+        const annotatedObjects = wktTokensToGeomObjects([{
+            start: 0,
+            end: 10,
+            line: 0,
+            endLine: 0,
+            wkt: 'POINT(1 1)',
+            annotation: {
+                fields: {
+                    id: 'stroke-001',
+                    tag: 'sweep-01',
+                    label: '1',
+                    custom: 'value',
+                },
+                id: 'stroke-001',
+                tag: 'sweep-01',
+                label: '1',
+                start: 0,
+                end: 43,
+                line: 0,
+                endLine: 0,
+            },
+        }])
+
+        expect(annotatedObjects[0].token.annotation?.fields).toEqual({
+            id: 'stroke-001',
+            tag: 'sweep-01',
+            label: '1',
+            custom: 'value',
+        })
+    })
 })
 
 describe('App map configuration', () => {

--- a/webview/src/App.test.tsx
+++ b/webview/src/App.test.tsx
@@ -2,7 +2,7 @@ import { act } from 'react'
 import { createRoot } from 'react-dom/client'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { type MsgFromWebview, type WktToken } from '@wkt-viewer/shared'
-import App, { wktTokensToGeomObjects } from './App'
+import App, { findSelectedGeomObject, wktTokensToGeomObjects } from './App'
 
 const testGlobal = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
 testGlobal.IS_REACT_ACT_ENVIRONMENT = true
@@ -126,6 +126,28 @@ describe('App map configuration', () => {
             root.unmount()
         })
         host.remove()
+    })
+})
+
+describe('findSelectedGeomObject', () => {
+    it('selects a geometry when the editor selection is on its annotation', () => {
+        const geomObjects = wktTokensToGeomObjects([{
+            start: 22,
+            end: 32,
+            line: 1,
+            endLine: 1,
+            wkt: 'POINT(1 1)',
+            annotation: {
+                fields: { id: 'stroke-001' },
+                id: 'stroke-001',
+                start: 0,
+                end: 21,
+                line: 0,
+                endLine: 0,
+            },
+        }])
+
+        expect(findSelectedGeomObject(geomObjects, 5, 0)?.token.annotation?.id).toBe('stroke-001')
     })
 })
 

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -37,12 +37,25 @@ export function wktTokensToGeomObjects(wktTokens: WktToken[]): GeomObject[] {
     })
 }
 
-function findSelectedGeomObject(geomObjects: GeomObject[], start: number, line: number): GeomObject | null {
-    const geomsOnSameLine = geomObjects.filter(obj => obj.token.line <= line && obj.token.endLine >= line)
+export function findSelectedGeomObject(geomObjects: GeomObject[], start: number, line: number): GeomObject | null {
+    const geomsOnSameLine = geomObjects.filter(obj => isTokenOrAnnotationOnLine(obj.token, line))
     // Find the first geometry that contains the start position, or the first on the line.
-    return geomsOnSameLine.find(obj => obj.token.start <= start && obj.token.end >= start) ?? geomsOnSameLine[0] ?? null
+    return geomsOnSameLine.find(obj => containsTokenOrAnnotationOffset(obj.token, start)) ?? geomsOnSameLine[0] ?? null
 }
 
+function isTokenOrAnnotationOnLine(token: WktToken, line: number): boolean {
+    if (token.line <= line && token.endLine >= line) return true
+
+    const annotation = token.annotation
+    return annotation !== undefined && annotation.line <= line && annotation.endLine >= line
+}
+
+function containsTokenOrAnnotationOffset(token: WktToken, start: number): boolean {
+    if (token.start <= start && token.end >= start) return true
+
+    const annotation = token.annotation
+    return annotation !== undefined && annotation.start <= start && annotation.end >= start
+}
 
 export default function App() {
     const [geomObjects, setGeomObjects] = useState<GeomObject[]>([])

--- a/webview/src/GeomObjectsList.tsx
+++ b/webview/src/GeomObjectsList.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { GeomObject } from './App'
+import { getAnnotationTitle, getTagColor, matchesAnnotationQuery } from './annotation'
 
 export function GeomObjectsList({
     geomObjects,
@@ -11,6 +12,9 @@ export function GeomObjectsList({
     onSelect?: (obj: GeomObject) => void
 }) {
     const listContainerRef = useRef<HTMLUListElement  | null>(null)
+    const [query, setQuery] = useState('')
+    const normalizedQuery = query.trim().toLowerCase()
+    const filteredGeomObjects = geomObjects.filter(obj => matchesAnnotationQuery(obj.token.annotation, normalizedQuery))
     
     /* -------- Scroll the selected list item into view -------- */
     useEffect(() => {
@@ -23,38 +27,86 @@ export function GeomObjectsList({
     return (
         <div>
             <h3 style={{ margin: '4px 0 8px 0' }}>Geometries ({geomObjects.length})</h3>
+            <input
+                value={query}
+                onChange={event => setQuery(event.target.value)}
+                placeholder="Search id, tag, label"
+                style={{
+                    boxSizing: 'border-box',
+                    width: '100%',
+                    marginBottom: 8,
+                    padding: '6px 8px',
+                    borderRadius: 4,
+                    border: '1px solid #ddd',
+                    fontSize: 13,
+                }}
+            />
             <ul 
                 ref={listContainerRef}
                 style={{ listStyle: 'none', padding: 0, margin: 0 }}
             >
-                {geomObjects.map((obj, idx) => (
-                    <li key={obj.id}
-                        style={{
-                            marginBottom: 8,
-                            padding: 8,
-                            borderRadius: 8,
-                            background: obj.id === selectedId ? '#b3e5fc' : '#fff',
-                            boxShadow: '0 1px 3px #0001',
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: 8,
-                            cursor: 'pointer',
-                            border: '2px solid', // Always have a 2px border!
-                            borderColor: obj.id === selectedId ? '#0288d1' : 'transparent',
-                            transition: 'border-color 0.1s',
-                        }}
-                        // So that we can find this element and scroll it into view
-                        data-geom-id={obj.id}
-                        onClick={() => onSelect && onSelect(obj)}
-                    >
+                {filteredGeomObjects.map((obj) => {
+                    const originalIndex = geomObjects.indexOf(obj)
+                    const annotation = obj.token.annotation
+                    const tagColor = getTagColor(annotation?.tag)
+                    const title = annotation ? getAnnotationTitle(annotation) : undefined
 
-                        <div style={{ flex: 1 }}>
-                            <div style={{ fontWeight: 500 }}>#{idx + 1}</div>
-                            <div style={{ fontFamily: 'monospace', fontSize: 13, color: '#2e7d32' }}>{obj.feature.geometry.type}</div>
-                            <div style={{ fontFamily: 'monospace', fontSize: 12, wordBreak: 'break-all', color: '#666' }}>{obj.token.wkt}</div>
-                        </div>
-                    </li>
-                ))}
+                    return (
+                        <li key={obj.id}
+                            style={{
+                                marginBottom: 8,
+                                padding: 8,
+                                borderRadius: 8,
+                                background: obj.id === selectedId ? '#b3e5fc' : '#fff',
+                                boxShadow: '0 1px 3px #0001',
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 8,
+                                cursor: 'pointer',
+                                border: '2px solid', // Always have a 2px border!
+                                borderColor: obj.id === selectedId ? '#0288d1' : 'transparent',
+                                transition: 'border-color 0.1s',
+                            }}
+                            // So that we can find this element and scroll it into view
+                            data-geom-id={obj.id}
+                            title={title}
+                            onClick={() => onSelect && onSelect(obj)}
+                        >
+
+                            <div style={{ flex: 1, minWidth: 0 }}>
+                                <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
+                                    {tagColor && (
+                                        <span
+                                            aria-hidden="true"
+                                            style={{
+                                                width: 10,
+                                                height: 10,
+                                                borderRadius: 2,
+                                                background: tagColor,
+                                                flex: '0 0 auto',
+                                            }}
+                                        />
+                                    )}
+                                    <div style={{ fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                                        {annotation?.label ?? annotation?.id ?? `#${originalIndex + 1}`}
+                                    </div>
+                                </div>
+                                {annotation?.id && (
+                                    <div style={{ fontFamily: 'monospace', fontSize: 12, color: '#444', wordBreak: 'break-all' }}>
+                                        {annotation.id}
+                                    </div>
+                                )}
+                                {annotation?.tag && (
+                                    <div style={{ fontFamily: 'monospace', fontSize: 12, color: '#555', wordBreak: 'break-all' }}>
+                                        {annotation.tag}
+                                    </div>
+                                )}
+                                <div style={{ fontFamily: 'monospace', fontSize: 13, color: '#2e7d32' }}>{obj.feature.geometry.type}</div>
+                                <div style={{ fontFamily: 'monospace', fontSize: 12, wordBreak: 'break-all', color: '#666' }}>{obj.token.wkt}</div>
+                            </div>
+                        </li>
+                    )
+                })}
             </ul>
         </div>
     )

--- a/webview/src/GeomObjectsMap.tsx
+++ b/webview/src/GeomObjectsMap.tsx
@@ -2,6 +2,7 @@ import * as LL from 'leaflet'
 import { useEffect, useMemo } from 'react'
 import * as RL from 'react-leaflet'
 import { GeomObject } from './App'
+import { getAnnotationEntries, getTagColor } from './annotation'
 import { getDirectionMarkers } from './DirectionMarker'
 import { calculateBoundingBox } from './geojson-util'
 import { DEFAULT_PATH_STYLE, POINT_RADIUS, POINT_RADIUS_SELECTED, SELECTED_PATH_STYLE } from './styles'
@@ -30,18 +31,33 @@ export function GeomObjectsMap({
 
     // Style function
     function styleFn(geomObj: GeomObject): LL.PathOptions {
-        return geomObj.id === selectedId ? SELECTED_PATH_STYLE : DEFAULT_PATH_STYLE
+        const tagColor = getTagColor(geomObj.token.annotation?.tag)
+        if (!tagColor) {
+            return geomObj.id === selectedId ? SELECTED_PATH_STYLE : DEFAULT_PATH_STYLE
+        }
+
+        return {
+            ...DEFAULT_PATH_STYLE,
+            color: tagColor,
+            fillColor: tagColor,
+            weight: geomObj.id === selectedId ? 4 : DEFAULT_PATH_STYLE.weight,
+            opacity: geomObj.id === selectedId ? 1 : DEFAULT_PATH_STYLE.opacity,
+            fillOpacity: geomObj.id === selectedId ? 0.45 : DEFAULT_PATH_STYLE.fillOpacity,
+        }
     }
 
     // Create marker for POINT geometries
     function createPointMarker(geomObj: GeomObject, latlng: LL.LatLng) {
+        const pathStyle = styleFn(geomObj)
         return LL.circleMarker(latlng, {
             radius: geomObj.id === selectedId ? POINT_RADIUS_SELECTED : POINT_RADIUS,
+            ...pathStyle,
         })
     }
 
     const handleFeatureClick = (geomObj: GeomObject) => (_feature: GeoJSON.Feature, layer: LL.Layer) => {
         layer.on('click', () => onSelect?.(geomObj))
+        bindMetadataTooltip(geomObj, layer)
     }
 
     const directionMarkers = useMemo(() => {
@@ -67,6 +83,40 @@ export function GeomObjectsMap({
             {directionMarkers}
         </>
     )
+}
+
+function bindMetadataTooltip(geomObj: GeomObject, layer: LL.Layer) {
+    const annotation = geomObj.token.annotation
+    if (!annotation) return
+
+    const tooltipLayer = layer as LL.Layer & {
+        bindTooltip?: (content: HTMLElement, options?: LL.TooltipOptions) => LL.Layer
+    }
+    tooltipLayer.bindTooltip?.(createMetadataTooltip(annotation), {
+        sticky: true,
+        direction: 'top',
+    })
+}
+
+function createMetadataTooltip(annotation: NonNullable<GeomObject['token']['annotation']>): HTMLElement {
+    const container = document.createElement('div')
+    container.style.display = 'grid'
+    container.style.gridTemplateColumns = 'auto 1fr'
+    container.style.gap = '2px 8px'
+
+    for (const [key, value] of getAnnotationEntries(annotation)) {
+        const keyElement = document.createElement('span')
+        keyElement.textContent = key
+        keyElement.style.fontWeight = '600'
+
+        const valueElement = document.createElement('span')
+        valueElement.textContent = value
+        valueElement.style.fontFamily = 'monospace'
+
+        container.append(keyElement, valueElement)
+    }
+
+    return container
 }
 
 // Allow middle-button drag panning without changing Leaflet's default drag behavior.

--- a/webview/src/annotation.ts
+++ b/webview/src/annotation.ts
@@ -1,0 +1,58 @@
+import { type WktAnnotation } from '@wkt-viewer/shared'
+
+const KNOWN_ANNOTATION_KEYS = new Set(['id', 'tag', 'label'])
+const TAG_COLORS = [
+    '#4E79A7',
+    '#F28E2B',
+    '#59A14F',
+    '#E15759',
+    '#76B7B2',
+    '#EDC948',
+    '#B07AA1',
+    '#FF9DA7',
+    '#9C755F',
+    '#BAB0AC',
+]
+
+export function getAnnotationEntries(annotation: WktAnnotation): Array<[string, string]> {
+    const entries: Array<[string, string]> = []
+    if (annotation.id) entries.push(['id', annotation.id])
+    if (annotation.tag) entries.push(['tag', annotation.tag])
+    if (annotation.label) entries.push(['label', annotation.label])
+
+    for (const [key, value] of Object.entries(annotation.fields)) {
+        if (!KNOWN_ANNOTATION_KEYS.has(key)) {
+            entries.push([key, value])
+        }
+    }
+
+    return entries
+}
+
+export function getAnnotationTitle(annotation: WktAnnotation): string {
+    return getAnnotationEntries(annotation)
+        .map(([key, value]) => `${key}=${value}`)
+        .join('\n')
+}
+
+export function getTagColor(tag: string | undefined): string | undefined {
+    if (!tag) return undefined
+
+    let hash = 0
+    for (let i = 0; i < tag.length; i++) {
+        hash = ((hash << 5) - hash + tag.charCodeAt(i)) | 0
+    }
+
+    return TAG_COLORS[Math.abs(hash) % TAG_COLORS.length]
+}
+
+export function matchesAnnotationQuery(annotation: WktAnnotation | undefined, query: string): boolean {
+    if (!query) return true
+    if (!annotation) return false
+
+    const normalizedQuery = query.toLowerCase()
+    return getAnnotationEntries(annotation)
+        .some(([key, value]) =>
+            key.toLowerCase().includes(normalizedQuery)
+            || value.toLowerCase().includes(normalizedQuery))
+}


### PR DESCRIPTION
﻿## Summary

- Parse `[awkt ...]` metadata annotations and attach them to the first following WKT geometry before the next annotation block
- Carry annotation metadata through the shared token contract into the webview model
- Show annotation metadata in the geometry list and map tooltip, with search/filter support and tag-based viewer coloring
- Document the annotation syntax in the README

Closes #20

## Verification

- `npm run build`
- `npm test`
- `npm run build -w webview`
- `npm run test -w webview`
